### PR TITLE
Fix press draft quote string

### DIFF
--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -9,8 +9,7 @@ export async function generatePressDraft(outlet: string, occasion: string) {
   return {
     subject: `[Presse] ${occasion}`,
     intro: `Worum geht's, warum lokal relevant.`,
-    quote: `"Wir freuen uns...",
-— Vorname Nachname`,
+    quote: `"Wir freuen uns...",\n— Vorname Nachname`,
     closing: `Kontakt: ...`,
   };
 }


### PR DESCRIPTION
## Summary
- fix malformed quote string in press draft generator stub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt; cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_6897951190e8832ebd7b2f8f9a0d828b