### PR TITLE
chore: force dynamic rendering for Prisma routes

### DIFF
--- a/app/api/campaign/seed/route.ts
+++ b/app/api/campaign/seed/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { seedCampaignPlan } from "@/lib/plan";
 
+export const dynamic = "force-dynamic";
+
 export async function POST(req: NextRequest) {
   try {
     const { name, eDayISO, guidelines } = await req.json();

--- a/app/api/export.csv/route.ts
+++ b/app/api/export.csv/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   const visits = await prisma.visit.findMany({ include: { contact: true } });
   const lines = ["name,street,postalCode,city,outcome,followUp,createdAt"];

--- a/app/api/export/ics/route.ts
+++ b/app/api/export/ics/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 type TaskRow = { id: number; title: string; startAt: Date | null; dueAt: Date | null };
 type ShiftRow = { id: number; title: string; startAt: Date; endAt: Date };
 

--- a/app/api/export/tableau/route.ts
+++ b/app/api/export/tableau/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   const visits = await prisma.visit.count();
   const issuesOpen = await prisma.issue.count({ where: { status: "open" } });

--- a/app/api/issues/[id]/route.ts
+++ b/app/api/issues/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
   const data = await req.json();
   const issue = await prisma.issue.update({ where: { id: Number(params.id) }, data });

--- a/app/api/issues/route.ts
+++ b/app/api/issues/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function POST(req: NextRequest) {
   const data = await req.json();
   const issue = await prisma.issue.create({ data });

--- a/app/api/shifts/assign/route.ts
+++ b/app/api/shifts/assign/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { assignShifts } from "@/lib/shifts";
 
+export const dynamic = "force-dynamic";
+
 type ShiftRow = { id: number };
 
 export async function POST(req: NextRequest) {

--- a/app/api/visits/route.ts
+++ b/app/api/visits/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function POST(req: NextRequest) {
   const data = await req.json();
   const visit = await prisma.visit.create({ data });

--- a/app/api/walklists/route.ts
+++ b/app/api/walklists/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   const lists = await prisma.walklist.findMany({ include: { items: true } });
   return NextResponse.json(lists);

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 function toEuro(cents: number) {
   return (cents/100).toLocaleString("de-DE", { style: "currency", currency: "EUR" });
 }

--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export default async function Content() {
   const campaign = await prisma.campaign.findFirst({ include: { contents: true } });
   return (

--- a/app/issues/page.tsx
+++ b/app/issues/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export default async function Issues() {
   const [open, done] = await Promise.all([
     prisma.issue.findMany({ where: { status: "open" } }),

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export default async function Plan() {
   const campaign = await prisma.campaign.findFirst({ include: { tasks: true } });
   if (!campaign) {

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export default async function Press() {
   const contacts = await prisma.pressContact.findMany();
   return (

--- a/app/walklists/page.tsx
+++ b/app/walklists/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 
+export const dynamic = "force-dynamic";
+
 export default async function Walklists() {
   const lists = await prisma.walklist.findMany({ include: { items: true } });
   return (


### PR DESCRIPTION
## Summary
- force dynamic rendering on Prisma-backed pages and route handlers to avoid build-time database errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897988fe854832e9b7a40c082aa4db6